### PR TITLE
feat:http依赖支持传递token

### DIFF
--- a/HTTP依赖.js
+++ b/HTTP依赖.js
@@ -1,10 +1,10 @@
 // ==UserScript==
 // @name         HTTP依赖
 // @author       错误
-// @version      1.1.1
+// @version      1.1.2
 // @description  为插件提供HTTP依赖管理。\nHTTP端口请按照自己的登录方案自行配置，配置完成后在插件设置填入。插件初始化时会自动获取HTTP地址对应的账号并保存。\n提供指令 .http 可以直接调用\n在其他插件中使用方法: globalThis.http.callApi(epId, method, data=null)\nepId为骰子账号QQ:12345，method为方法，如get_login_info，data为参数。\n方法可参见https://github.com/botuniverse/onebot-11/blob/master/api/public.md#%E5%85%AC%E5%BC%80-api
-// @timestamp    1733626761
-// 2024-12-08 10:59:21
+// @timestamp    1755278205
+// 2025-08-16 01:16:58
 // @license      MIT
 // @homepageURL  https://github.com/error2913/sealdice-js/
 // @updateUrl    https://raw.gitmirror.com/error2913/sealdice-js/main/HTTP依赖.js
@@ -18,7 +18,9 @@ if (!ext) {
 }
 
 seal.ext.registerTemplateConfig(ext, 'HTTP端口地址', ['http://127.0.0.1:8084'], '修改后保存并重载js');
+seal.ext.registerTemplateConfig(ext, 'HTTP Access Token', [''], '在这里填入你的Access Token，与上面的端口地址一一对应，如果没有则留空');
 seal.ext.registerOptionConfig(ext, "日志打印方式", "简短", ["永不", "简短", "详细"], '修改后保存并重载js');
+
 
 const urlMap = {};
 const logLevel = seal.ext.getOptionConfig(ext, "日志打印方式");
@@ -72,29 +74,40 @@ class Logger {
 
 const logger = new Logger('http');
 
-async function fetchData(url, data = null) {
+async function fetchData(url, token = '', data = null) {
     try {
-        const response = data === null ? await fetch(url) : await fetch(url, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(data),
-        });
+        const headers = {
+            'Content-Type': 'application/json',
+        };
 
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+
+        const options = {
+            method: data === null ? 'GET' : 'POST',
+            headers: headers,
+        };
+
+        if (data !== null) {
+            options.body = JSON.stringify(data);
+        }
+
+        const response = await fetch(url, options);
         const text = await response.text();
 
         if (!response.ok) {
             throw new Error(`请求失败! 状态码: ${response.status}\n响应体: ${text}`);
         }
         if (!text) {
-            throw new Error("响应体为空");
+            logger.info('响应体为空，但请求成功');
+            return {};
         }
 
         try {
-            const data = JSON.parse(text).data;
-            logger.info(`获取数据成功: ${JSON.stringify(data, null, 2)}`);
-            return data;
+            const responseData = JSON.parse(text);
+            logger.info(`获取数据成功: ${JSON.stringify(responseData.data, null, 2)}`);
+            return responseData.data;
         } catch (e) {
             throw new Error(`解析响应体时出错:${e}\n响应体:${text}`);
         }
@@ -104,29 +117,34 @@ async function fetchData(url, data = null) {
     }
 }
 
+
 async function init() {
     const ports = seal.ext.getTemplateConfig(ext, 'HTTP端口地址');
+    const tokens = seal.ext.getTemplateConfig(ext, 'HTTP Access Token');
 
     for (let i = 0; i < ports.length; i++) {
         const port = ports[i];
+        const token = tokens[i] || '';
         const url = `${port}/get_login_info`;
-        const data = await fetchData(url);
+        
+        const data = await fetchData(url, token); 
         if (data === null) {
             logger.error(`获取登录信息失败: ${port}`);
             continue;
         }
         const epId = `QQ:${data.user_id}`;
         const eps = seal.getEndPoints();
-        for (let i = 0; i < eps.length; i++) {
-            if (eps[i].userId === epId) {
-                urlMap[epId] = port;
-                logger.info(`找到${epId}端口: ${port}`);
+        for (let j = 0; j < eps.length; j++) {
+            if (eps[j].userId === epId) {
+                urlMap[epId] = { url: port, token: token };
+                logger.info(`找到 ${epId} 端口: ${port}`);
                 break;
             }
         }
     }
     logger.info('初始化完成，urlMap: ', JSON.stringify(urlMap, null, 2));
 }
+
 init();
 
 class Http {
@@ -152,11 +170,15 @@ class Http {
             return null;
         }
 
-        const url = `${urlMap[epId]}/${method}`;
+        const { url: baseUrl, token } = urlMap[epId]; 
+        const url = `${baseUrl}/${method}`;
+
         logger.info('请求地址: ', url, '\n请求参数: ', JSON.stringify(data));
-        const result = await fetchData(url, data);
+        
+        const result = await fetchData(url, token, data);
         return result;
     }
+
 }
 
 globalThis.http = new Http(urlMap);


### PR DESCRIPTION
之前的实现不支持需要认证的 OneBot HTTP 端点，导致无法连接配置了 access-token 的服务。
本次更新重构了 fetchData 函数及相关调用逻辑，以支持OneBot v11 标准推荐的 Bearer Token 认证方式。
此修改向后兼容，如果 Access Token 配置项留空，则会发送不带认证的请求，行为与旧版一致。